### PR TITLE
Build some binaries only when SDK is installed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ catkin_package(
 
 include_directories(include
   ${catkin_INCLUDE_DIRS}
-  $ENV{LEAP_SDK}/include
+  if($ENV{LEAP_SDK} $ENV{LEAP_SDK}/include)
 )
 
 install(PROGRAMS
@@ -40,14 +40,14 @@ install(PROGRAMS
   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
-add_executable(leap_camera src/leap_camera.cpp)
- 
-target_link_libraries(leap_camera
-  ${catkin_LIBRARIES} $ENV{LEAP_SDK}/lib/x64/libLeap.so
+if($ENV{LEAP_SDK})
+  add_executable(leap_camera src/leap_camera.cpp)
+  target_link_libraries(leap_camera
+    ${catkin_LIBRARIES} $ENV{LEAP_SDK}/lib/x64/libLeap.so
   )
 
-add_executable(leap_hands src/leap_hands.cpp)
- 
-target_link_libraries(leap_hands
-  ${catkin_LIBRARIES} $ENV{LEAP_SDK}/lib/x64/libLeap.so
+  add_executable(leap_hands src/leap_hands.cpp)
+  target_link_libraries(leap_hands
+    ${catkin_LIBRARIES} $ENV{LEAP_SDK}/lib/x64/libLeap.so
   )
+endif()


### PR DESCRIPTION
A workaround to https://github.com/ros-drivers/leap_motion/issues/7.

When SDK isn't available, catkin skips to build a couple of binaries that are introduced in https://github.com/ros-drivers/leap_motion/pull/3. That said, DEB won't included those binaries since AFAIK I don't think Leap SDK is available on ROS buildfarm (and won't be soon).

Fyi @YuOhara
