### PR TITLE
ROS msg publish frequency from commandline.

### DIFF
--- a/test/test_leap_motion.test
+++ b/test/test_leap_motion.test
@@ -1,0 +1,3 @@
+<launch>
+  <include file="$(find leap_motion)/test/test_sender.test" />
+</launch>

--- a/test/test_sender.test
+++ b/test/test_sender.test
@@ -1,0 +1,19 @@
+<launch>
+  <arg name="freq_prefix" default="--freq=" />
+  <arg name="freq_value" default="0.02" />
+  <arg name="freq_limit" default="50" />
+  <arg name="topicname_leapdata" default="/leapmotion/data" />
+
+  <node name="sender_freq" 
+        pkg="leap_motion" type="sender.py" args="$(arg freq_prefix)$(arg freq_value)" />
+
+  <test test-name="nodelet_sender_test"
+        pkg="rostest" type="hztest" name="hztest_leap_sender" >
+    <param name="hz" value="$(arg freq_value)" />
+    <param name="hzerror" value="$(arg freq_limit)" />
+    <param name="test_duration" value="10.0" />    
+    <param name="topic" value="$(arg topicname_leapdata)" />  
+    <param name="wait_time" value="2.0" />  
+  </test>
+
+</launch>


### PR DESCRIPTION
Currently the frequency of publishing sensed info as a ROS message is [hardcoded as 0.01](https://github.com/ros-drivers/leap_motion/blob/fcee4de0bb364dd826770b3635ce3ccf1b7b45d0/scripts/sender.py#L41). This PR enables to set it from commandline argument, while default frequency is set as 0.01.

BEFORE: 
```
$  rosrun leap_motion sender.py 
```

AFTER: 
```
$  rosrun leap_motion sender.py 
or
$  rosrun leap_motion sender.py --freq 0.05
```