### PR TITLE
Utilize private parameter declaration.

### DIFF
--- a/launch/sensor_sender.launch
+++ b/launch/sensor_sender.launch
@@ -1,0 +1,9 @@
+<launch>
+  <arg name="freq_prefix" default="_freq" />
+  <arg name="freq_value" default="0.01" />
+  <arg name="freq_limit" default="50" />
+
+  <node name="sender_freq" 
+        pkg="leap_motion" type="sender.py" args="$(arg freq_prefix):=$(arg freq_value)" />
+
+</launch>

--- a/scripts/sender.py
+++ b/scripts/sender.py
@@ -9,22 +9,22 @@ from leap_motion.msg import leap
 from leap_motion.msg import leapros
 
 FREQUENCY_ROSTOPIC_DEFAULT = 0.01
-PARAMNAME_FREQ = '/leapmotion/freq'
+NODENAME = 'leap_pub'
+PARAMNAME_FREQ = 'freq'
+PARAMNAME_FREQ_ENTIRE = '/' + NODENAME + '/' + PARAMNAME_FREQ
 
-# Obviously, this method publishes the data defined in leapros.msg to /leapmotion/data
-def sender(freq=FREQUENCY_ROSTOPIC_DEFAULT):
+def sender():
     '''
-    @param freq: Frequency to publish sensed info as ROS message
+    This method publishes the data defined in leapros.msg to /leapmotion/data
     '''
-    rospy.set_param(PARAMNAME_FREQ, freq)
-    rospy.loginfo("Parameter set on server: PARAMNAME_FREQ={}, freq={}".format(rospy.get_param(PARAMNAME_FREQ, FREQUENCY_ROSTOPIC_DEFAULT), freq))
+    rospy.loginfo("Parameter set on server: PARAMNAME_FREQ={}".format(rospy.get_param(PARAMNAME_FREQ_ENTIRE, FREQUENCY_ROSTOPIC_DEFAULT)))
 
     li = leap_interface.Runner()
     li.setDaemon(True)
     li.start()
     # pub     = rospy.Publisher('leapmotion/raw',leap)
     pub_ros   = rospy.Publisher('leapmotion/data',leapros)
-    rospy.init_node('leap_pub')
+    rospy.init_node(NODENAME)
 
     while not rospy.is_shutdown():
         hand_direction_   = li.get_hand_direction()
@@ -49,16 +49,11 @@ def sender(freq=FREQUENCY_ROSTOPIC_DEFAULT):
         # We don't publish native data types, see ROS best practices
         # pub.publish(hand_direction=hand_direction_,hand_normal = hand_normal_, hand_palm_pos = hand_palm_pos_, hand_pitch = hand_pitch_, hand_roll = hand_roll_, hand_yaw = hand_yaw_)
         pub_ros.publish(msg)
-        rospy.sleep(rospy.get_param(PARAMNAME_FREQ, FREQUENCY_ROSTOPIC_DEFAULT))
+        rospy.sleep(rospy.get_param(PARAMNAME_FREQ_ENTIRE, FREQUENCY_ROSTOPIC_DEFAULT))
 
 
 if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='LeapMotion ROS driver. Message Sender module to ROS world using LeapSDK.')
-    parser.add_argument('--freq', help='Frequency to publish sensed info as ROS message', type=float)
-    args, unknown = parser.parse_known_args()
-    if not args.freq:
-        args.freq = FREQUENCY_ROSTOPIC_DEFAULT
     try:
-        sender(args.freq)
+        sender()
     except rospy.ROSInterruptException:
         pass

--- a/test/test_sender.test
+++ b/test/test_sender.test
@@ -1,19 +1,31 @@
 <launch>
-  <arg name="freq_prefix" default="--freq=" />
+  <arg name="freq_prefix" default="_freq" />
   <arg name="freq_value" default="0.02" />
-  <arg name="freq_limit" default="50" />
   <arg name="topicname_leapdata" default="/leapmotion/data" />
+  <arg name="test_duration_sender" default="5.0" />
+  <arg name="test_waittime" default="5.0" />
 
   <node name="sender_freq" 
-        pkg="leap_motion" type="sender.py" args="$(arg freq_prefix)$(arg freq_value)" />
+        pkg="leap_motion" type="sender.py">
+    <param name="$(arg freq_prefix)" value="$(arg freq_value)" />
+  </node>
 
-  <test test-name="nodelet_sender_test"
-        pkg="rostest" type="hztest" name="hztest_leap_sender" >
+  <test pkg="rostest" type="hztest" name="hztest_leap_sender_normal"
+        test-name="test_sender_normal" >
     <param name="hz" value="$(arg freq_value)" />
-    <param name="hzerror" value="$(arg freq_limit)" />
-    <param name="test_duration" value="10.0" />    
+    <param name="hzerror" value="50" />
+    <param name="test_duration" value="$(arg test_duration_sender)" />    
     <param name="topic" value="$(arg topicname_leapdata)" />  
-    <param name="wait_time" value="2.0" />  
+    <param name="wait_time" value="$(arg test_waittime)" />  
+  </test>
+
+  <test test-name="test_sender_aggressive"
+        pkg="rostest" type="hztest" name="hztest_leap_sender_aggressive" >
+    <param name="hz" value="$(arg freq_value)" />
+    <param name="hzerror" value="90" />
+    <param name="test_duration" value="$(arg test_duration_sender)" />    
+    <param name="topic" value="$(arg topicname_leapdata)" />  
+    <param name="wait_time" value="$(arg test_waittime)" />  
   </test>
 
 </launch>


### PR DESCRIPTION
Thanks to the comment https://github.com/ros-drivers/leap_motion/pull/14#issuecomment-97610401 by @jack-oquin, I now realize that Parameters can be defined from commandline. This PR replaces the explicit `rospy.set_param` call.

Known problem is, however, rostest fail for some reason. Run by `rosrun` works for me.

> average rate (90.828Hz) exceeded maximum (50.020Hz)

Avg rage is expected to become below 50 here. Seems to me the parameters set from commandline are not read by rostest. 

```
$ rostest leap_motion test_leap_motion.test 
... logging to /home/rospasta/.ros/log/rostest-tork-kudu1-22544.log
[ROSUNIT] Outputting test results to /home/rospasta/catkin_ws/build/stackit_robot_moveit_config/test_results/leap_motion/rostest-test_test_leap_motion.xml
  pub_ros   = rospy.Publisher('leapmotion/data',leapros)
testnodelet_sender_test ... ok

[ROSTEST]-----------------------------------------------------------------------

[leap_motion.rosunit-nodelet_sender_test/test_hz][FAILURE]----------------------
average rate (90.828Hz) exceeded maximum (50.020Hz)
  File "/usr/lib/python2.7/unittest/case.py", line 331, in run
    testMethod()
  File "/home/rospasta/cws_drivers/src/ros_comm/tools/rostest/nodes/hztest", line 117, in test_hz
    self._test_hz(hz, hzerror, topic, test_duration, wait_time)
  File "/home/rospasta/cws_drivers/src/ros_comm/tools/rostest/nodes/hztest", line 190, in _test_hz
    (rate, self.max_rate))
  File "/usr/lib/python2.7/unittest/case.py", line 424, in assertTrue
    raise self.failureException(msg)
--------------------------------------------------------------------------------


SUMMARY
 * RESULT: FAIL
 * TESTS: 1
 * ERRORS: 0
 * FAILURES: 1
```
