### PR TITLE
Add a dependency of the driver library Leap-2*.deb

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(leap_motion)
 
-find_package(catkin REQUIRED COMPONENTS roscpp rospy roslib std_msgs geometry_msgs message_generation sensor_msgs visualization_msgs camera_info_manager rospack camera_calibration_parsers)
+find_package(catkin REQUIRED COMPONENTS libgl1-mesa-glx-lts roscpp rospy roslib std_msgs geometry_msgs message_generation sensor_msgs visualization_msgs camera_info_manager rospack camera_calibration_parsers)
 
 find_package(OpenMP)
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} ${OpenMP_C_FLAGS}")

--- a/package.xml
+++ b/package.xml
@@ -19,6 +19,7 @@
   <build_depend>camera_info_manager</build_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>image_transport</build_depend>
+  <build_depend>libgl1-mesa-glx-lts</build_depend>
   <build_depend>message_generation</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>roslib</build_depend>
@@ -31,6 +32,7 @@
   <run_depend>camera_info_manager</run_depend>
   <run_depend>geometry_msgs</run_depend>
   <run_depend>image_transport</run_depend>
+  <run_depend>libgl1-mesa-glx-lts</run_depend>
   <run_depend>message_runtime</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>roslib</run_depend>


### PR DESCRIPTION
Looks like the manufacturer's driver `Leap-2.2.5+23475-x64.deb` depends on `libgl1-mesa-glx-lts` (and also on other packages that are transitively depended). I thought it's friendlier for ROS driver to re-iterate this dependency so that users won't miss these dependencies, despite redundancy.

```
$ dpkg -I Leap-2.2.5+26752-x64.deb 
 new debian package, version 2.0.
 size 78297358 bytes: control archive=4261 bytes.
     568 bytes,    10 lines      control              
    7034 bytes,    97 lines      md5sums              
    2216 bytes,    50 lines   *  postinst             #!/bin/bash
     459 bytes,    15 lines   *  postrm               #!/bin/bash
     112 bytes,     4 lines   *  prerm                #!/bin/bash
 Package: leap
 Version: 2.2.5+26752
 Section: Utilities
 Priority: optional
 Architecture: amd64
 Depends: libc6 (>= 2.15-0), libgl1-mesa-glx (>= 7.7.1) | libgl1-mesa-glx-lts-precise (>= 7.7.1) | libgl1-mesa-glx-lts-quantal (>= 7.7.1) | libgl1-mesa-glx-lts-raring (>= 7.7.1) | libgl1-mesa-glx-lts-saucy (>= 7.7.1) | libgl1-mesa-glx-lts-trusty (>= 7.7.1), libglu1-mesa (>= 7.7.1), libxi6 (>= 2:1.3-3), libxxf86vm1 (>= 1:1.1.0-2), libdbus-1-3 (>= 1.0.2)
 Installed-Size: 246004
 Maintainer: Leap Motion Support <support@leapmotion.com>
 Description: Leap Motion Debian package
```

This requires https://github.com/ros/rosdistro/pull/10277 to be merged.