### PR TITLE
[Indigo onward] Changelog for 0.0.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,11 +19,14 @@ env:
     - ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu NOT_TEST_BUILD=true NOT_TEST_INSTALL=true
     - ROS_DISTRO="jade"   ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu NOT_TEST_BUILD=true NOT_TEST_INSTALL=true
     - ROS_DISTRO="jade"   PRERELEASE=true
-    - ROS_DISTRO="kinetic"  NOT_TEST_BUILD=true NOT_TEST_INSTALL=true
+    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros/ubuntu NOT_TEST_INSTALL=true
+    - ROS_DISTRO="kinetic"  ROS_REPOSITORY_PATH=http://packages.ros.org/ros-shadow-fixed/ubuntu NOT_TEST_INSTALL=true
+    - ROS_DISTRO="kinetic"  PRERELEASE=true
 matrix:
   allow_failures:
     - env: ROS_DISTRO="indigo" PRERELEASE=true  # Run docker-based ROS prerelease test http://wiki.ros.org/bloom/Tutorials/PrereleaseTest Because we might not want to run prerelease test for all PRs, it's omitted from pass-fail criteria.
     - env: ROS_DISTRO="jade"   PRERELEASE=true
+    - env: ROS_DISTRO="kinetic"  PRERELEASE=true
 install:
   - git clone https://github.com/ros-industrial/industrial_ci.git .ci_config
 script:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,11 @@
 Changelog for package leap_motion
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* [fix] ROS Hydro onward requires queue_size option `#31 <https://github.com/ros-drivers/leap_motion/issues/31>`_
+* Contributors: Kei Okada
+
 0.0.10 (2016-06-18)
 -------------------
 * [fix][sys] launch and camera_info directory should be installed


### PR DESCRIPTION
Also adding in Travis config:
- ROS Kinetic support.
- Utilize more of the ROS Prerelease test on Travis https://github.com/ros-industrial/industrial_ci/pull/85