### PR TITLE
Adding bone, wrist, and elbow orientation output.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,6 +34,7 @@ find_package(OpenMP)
 ## Generate messages in the 'msg' folder
 add_message_files(
   FILES
+  Arm.msg
   Bone.msg
   Finger.msg
   Gesture.msg

--- a/msg/Arm.msg
+++ b/msg/Arm.msg
@@ -1,0 +1,13 @@
+std_msgs/Header header
+
+# The position and orientation of the elbow. 
+geometry_msgs/Pose elbow
+
+# The position and orientation of the wrist. 
+geometry_msgs/Pose wrist
+
+# The midpoint of the forearm. 
+float32[] center
+
+# The direction vector of the forearm
+geometry_msgs/Vector3 direction

--- a/msg/Hand.msg
+++ b/msg/Hand.msg
@@ -49,15 +49,12 @@ float32 sphere_radius
 # The center of a sphere fit to the curvature of this hand. 
 float32[] sphere_center
 
-# The position of the wrist of this hand. 
-float32[] wrist_position
-
-# The position of the elbow of this hand. 
-float32[] elbow_position
-
 # A string containing a brief, human readable description of the Hand object. 
 string to_string 
 
-# A list of fingers and gestures assosciated with this hand
+# A list of fingers and gestures associated with this hand
 Finger[] finger_list
 Gesture[] gesture_list
+
+# The arm associated with this hand
+Arm arm

--- a/src/lmc_visualizer_node.cpp
+++ b/src/lmc_visualizer_node.cpp
@@ -198,6 +198,15 @@ visualization_msgs::Marker createHandOutline(const leap_motion::Human::ConstPtr 
             line_list.points.push_back(p);
         }
     }
+    geometry_msgs::Point p;
+    p.x = current_hand.arm.elbow.position.x;
+    p.y = current_hand.arm.elbow.position.y;
+    p.z = current_hand.arm.elbow.position.z;
+    line_list.points.push_back(p);
+    p.x = current_hand.arm.wrist.position.x;
+    p.y = current_hand.arm.wrist.position.y;
+    p.z = current_hand.arm.wrist.position.z;
+    line_list.points.push_back(p);
 
     return line_list;
 }


### PR DESCRIPTION
This is tested and working (in ROS Melodic).

It modifies lmc_listener.cpp to make use of the Leap SDK's rotation basis reporting, convert the rotation matrices to ROS quaternions, and populate the orientation field of the reported bone poses. Left hand pose rotations are converted from left-handed to right-handed, because the majority of API customers would want that, I think (I do).

It also adds an `arm` field to the `hand` message in order to report the elbow and wrist poses, rather than just positions.

It also adds a forearm (elbow->wrist) bone to the visualisation marker publishing.